### PR TITLE
Fix missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 python-dotenv==1.0.0
+requests~=2.31.0
+pydantic~=2.1.1

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     package_dir={"": "src"},
     include_package_data=True,
-    install_requires=["python-dotenv==1.0.0"],
+    install_requires=["python-dotenv==1.0.0", "requests~=2.31.0", "pydantic~=2.1.1"],
     extras_require={'dev': ['pytest', 'tox']},
     entry_points={},
 )


### PR DESCRIPTION
在Venv模式下直接安装vercel_kv 
会出现缺少requests和pydantic的报错
<img width="517" alt="cb92245befb526bea3129528419b50c" src="https://github.com/bestK/python-vercel-kv/assets/60541541/702da7d5-65c1-4fd3-918e-4bc118622be3">
